### PR TITLE
Customize height, duration and delay

### DIFF
--- a/Example/Pods/Target Support Files/JDropDownAlert/Info.plist
+++ b/Example/Pods/Target Support Files/JDropDownAlert/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/JDropDownAlert/Classes/JDropDownAlert.swift
+++ b/JDropDownAlert/Classes/JDropDownAlert.swift
@@ -284,7 +284,7 @@ public class JDropDownAlert: UIButton {
 }
 
 
-extension UIColor {
+private extension UIColor {
     class func lightRed() -> UIColor {
         return UIColor(red: 255/255, green: 102/255, blue: 102/255, alpha: 0.9)
     }

--- a/JDropDownAlert/Classes/JDropDownAlert.swift
+++ b/JDropDownAlert/Classes/JDropDownAlert.swift
@@ -40,9 +40,9 @@ public class JDropDownAlert: UIButton {
     
     // default values
     // You can change this values to customize
-    private let height: CGFloat = 70
-    private let duration = 0.3
-    private var delay: Double = 2.0
+    public var height: CGFloat = 70
+    public var duration: NSTimeInterval = 0.3
+    public var delay: Double = 2.0
     
     private var titleFrame: CGRect!
     private var topLabel = UILabel()
@@ -179,7 +179,7 @@ public class JDropDownAlert: UIButton {
         addWindowSubview(self)
         configureProperties(title, message: message, textColor: textColor, backgroundColor: backgroundColor)
         
-        UIView.animateWithDuration(self.duration) {
+        UIView.animateWithDuration(duration) {
             
             switch self.direction {
             case .ToRight:


### PR DESCRIPTION
It appears (judging by the comment above the properties) that the height, duration and delay properties were mistakenly marked as `private`. This PR marks them as `public`, allowing the framework user to customize these properties.

It also marks the UIColor extension as private, seeing as how there is no need to expose it to the framework user.